### PR TITLE
Adding added property to CLCGVC to track last frame width

### DIFF
--- a/CLCGAPNHelper.m
+++ b/CLCGAPNHelper.m
@@ -83,7 +83,9 @@
 +(BOOL)hasPushNotificationsEnabled
 {
   if (clcg_os_geq(@"8")) {
+#pragma deploymate push "ignored-api-availability"
     return [[UIApplication sharedApplication] isRegisteredForRemoteNotifications];
+#pragma deploymate pop
   } else {
     return ([[UIApplication sharedApplication] enabledRemoteNotificationTypes]
             != UIRemoteNotificationTypeNone);
@@ -113,12 +115,14 @@
 
   UIApplication *app = [UIApplication sharedApplication];
   if (clcg_os_geq(@"8")) {
+#pragma deploymate push "ignored-api-availability"
     [app registerUserNotificationSettings:
      [UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeSound
                                                    | UIUserNotificationTypeAlert
                                                    | UIUserNotificationTypeBadge)
                                        categories:nil]];
     [app registerForRemoteNotifications];
+#pragma deploymate pop
   } else {
     [app registerForRemoteNotificationTypes: (UIRemoteNotificationTypeBadge
                                               | UIRemoteNotificationTypeAlert
@@ -172,9 +176,11 @@
 {
   UIApplication *app = [UIApplication sharedApplication];
   if (clcg_os_geq(@"8")) {
+#pragma deploymate push "ignored-api-availability"
     UIUserNotificationSettings *notif_settings = [app currentUserNotificationSettings];
     return ([app isRegisteredForRemoteNotifications]
             && (notif_settings.types & UIUserNotificationTypeBadge));
+#pragma deploymate pop
   } else {
     return [app enabledRemoteNotificationTypes] & UIRemoteNotificationTypeBadge;
   }

--- a/CLCGImageLoader.h
+++ b/CLCGImageLoader.h
@@ -51,6 +51,18 @@ typedef void (^CLCGImageLoaderCallback)(UIImage *img, int http_status);
 
 @property(nonatomic,retain,readonly) NSCache *cache;
 
+/*!
+ Singleton instance of the CLCGImageLoader
+ */
++(CLCGImageLoader*)i;
+
+/*!
+ @return The largest size image currently stored in cache.
+ */
++(UIImage*)bestCachedImageForURL:(NSString*)normal_url
+                       retinaURL:(NSString*)retina_url
+                     retinaHDURL:(NSString*)retina_hd_url;
+
 /*! 
  @deprecated
  */

--- a/CLCGImageView.h
+++ b/CLCGImageView.h
@@ -41,4 +41,8 @@ typedef void (^CLCGImageViewOnLoadCallback)(UIImage *img, int http_status);
              retinaURL:(NSString*)retina_url
            retinaHDURL:(NSString*)retina_hd_url;
 
+-(void)loadCachedImageIfPossibleForURL:(NSString*)normal_url
+                             retinaURL:(NSString*)retina_url
+                           retinaHDURL:(NSString*)retina_hd_url;
+
 @end

--- a/CLCGImageView.m
+++ b/CLCGImageView.m
@@ -68,6 +68,21 @@
             retinaHDURL:nil];
 }
 
+
+-(void)loadCachedImageIfPossibleForURL:(NSString*)normal_url
+                             retinaURL:(NSString*)retina_url
+                           retinaHDURL:(NSString*)retina_hd_url
+{
+    UIImage *img = [CLCGImageLoader bestCachedImageForURL:normal_url
+                                                retinaURL:retina_url
+                                              retinaHDURL:retina_hd_url];
+    if (img) {
+      [self setImage:img];
+      return;
+    }
+}
+
+
 -(void)loadImageForURL:(NSString*)normal_url
              retinaURL:(NSString*)retina_url
            retinaHDURL:(NSString*)retina_hd_url

--- a/CLCGTableViewVC.m
+++ b/CLCGTableViewVC.m
@@ -107,6 +107,7 @@
   expandmask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
   [v setAutoresizingMask:expandmask];
   [tv setAutoresizingMask:expandmask];
+  v.translatesAutoresizingMaskIntoConstraints = YES;
 
   // build view hierarchy
   [self setView:v];

--- a/CLCGVC.h
+++ b/CLCGVC.h
@@ -140,6 +140,19 @@ enum CLCGLoadingState {
 //------------------------------------------------------------------------------
 #pragma mark - Misc
 
+/*!
+ Width of view when it was last on the screen. Used to detect if the screen was
+ rotated upon reappearing.
+ 
+ Will be set in viewDidLayoutSubview and on viewWillDisappear. Subclasses 
+ depending on this value in those methods should use/save it before calling
+ super in either of those methods.
+ */
+@property(nonatomic)        CGFloat  lastViewWidth;
+-(BOOL)viewWidthWasChanged;
+
+
+
 @property(nonatomic,weak) id<CLCGPopoverContentDelegate> popoverContentDelegate;
 
 /*!

--- a/CLCGVC.m
+++ b/CLCGVC.m
@@ -78,6 +78,27 @@
 }
 
 
+-(void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+  self.lastViewWidth = [self.view w];
+}
+
+
+-(void)viewWillDisappear:(BOOL)animated
+{
+  [super viewWillDisappear:animated];
+  self.lastViewWidth = [self.view w];
+}
+
+
+-(BOOL)viewWidthWasChanged
+{
+  return (self.lastViewWidth != 0) &&
+        (self.lastViewWidth != self.view.w);
+}
+
+
 //------------------------------------------------------------------------------
 #pragma mark - Spinner / Loading view
 

--- a/clcg_debug.h
+++ b/clcg_debug.h
@@ -48,8 +48,10 @@ extern "C" {
 ///////////////////////////////////////////////////////////////////////////////
 // debugging macros
 
+// Uncomment this if you want to turn on verbose logging
+//#define CLCG_LOGGING 1;
 
-#ifdef DEBUG
+#ifdef CLCG_LOGGING
 #define CLCG_P(xx, ...)  NSLog(@"%s(%d): " xx, __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
 #else
 #define CLCG_P(xx, ...)  ((void)0)
@@ -58,7 +60,7 @@ extern "C" {
 
 
 /* e.g. CLCG_PSIZE(@"screen bounds", [[UIScreen mainScreen] bounds]); */
-#ifdef DEBUG
+#ifdef CLCG_LOGGING
 #define CLCG_PRECT(s,r) NSLog(@"%s(%d): %@ (%.0f,%.0f) (%.0f,%.0f)", __PRETTY_FUNCTION__, \
         __LINE__, s, r.origin.x, r.origin.y, r.size.width, r.size.height)
 #else
@@ -68,7 +70,7 @@ extern "C" {
 
 
 /* e.g. CLCG_PSIZE(@"screen size", [[UIScreen mainScreen] bounds].size); */
-#ifdef DEBUG
+#ifdef CLCG_LOGGING
 #define CLCG_PSIZE(s,r) NSLog(@"%s(%d): %@ (%.0f,%.0f)", __PRETTY_FUNCTION__, \
         __LINE__, s, r.width, r.height);
 #else


### PR DESCRIPTION
We have a rotation issue where we need to resize any frames of view controllers if the view gets rotated while the view is not on screen (e.g. if a another tab is currently visible or if the VC view is not on top of the nav stack.)

We are using this inside viewWillLayoutSubviews where we invalidate our collection view layout and we only want to do that if something has changed. viewWillLayoutSubviews gets called on iOS 8 when returning back to a VC even when the frame hasn't changed.
